### PR TITLE
fix: improve mobile layout and spacing

### DIFF
--- a/src/styles/AddToPlaylistModal.css
+++ b/src/styles/AddToPlaylistModal.css
@@ -9,7 +9,7 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  z-index: 1000;
+  z-index: 1002;
   padding-bottom: 120px; /* Account for music player height */
 }
 

--- a/src/styles/Listen.css
+++ b/src/styles/Listen.css
@@ -31,5 +31,6 @@
     margin-left: 0;
     max-width: 100%;
     justify-content: flex-start; /* standard flow */
+    padding: 0; /* Remove horizontal padding when ListenNav is on top */
   }
 }

--- a/src/styles/SongDetails.css
+++ b/src/styles/SongDetails.css
@@ -317,6 +317,13 @@
   .song-details-title {
     font-size: 2rem;
   }
+  /* Shrink share button on mobile */
+  .share-button {
+    padding: 0.4rem;
+    font-size: 0.8rem;
+    top: 0.5rem;
+    right: 0.5rem;
+  }
 
   .song-details-content {
     grid-template-columns: 1fr;


### PR DESCRIPTION
- Reduce share button size on mobile (padding: 0.4rem, font-size: 0.8rem)
- Remove horizontal padding from Listen content on mobile when ListenNav moves to top
- Allow Albums page and other Listen pages to use full width on mobile screens
- Improve overall mobile responsiveness across the app